### PR TITLE
Bump alpine version, add dependencies

### DIFF
--- a/Dockerfile.new
+++ b/Dockerfile.new
@@ -1,5 +1,5 @@
-FROM alpine:3.16 AS builder
-RUN apk add --no-cache 'crystal=1.4.1-r0' shards sqlite-static yaml-static yaml-dev libxml2-dev zlib-static openssl-libs-static openssl-dev musl-dev yq
+FROM docker.io/library/alpine:3.18 AS builder
+RUN apk add --no-cache crystal="1.8.2-r0" shards sqlite-static yaml-static yaml-dev libxml2-static  zlib-static openssl-libs-static openssl-dev musl-dev libxml2-dev xz-static yq
 
 ARG add_build_args
 
@@ -29,7 +29,7 @@ RUN crystal build ./src/invidious.cr ${add_build_args} \
 
 #RUN shards build --release --static sentry_crash_handler
 
-FROM alpine:3.16
+FROM docker.io/library/alpine:3.18
 RUN apk add --no-cache librsvg ttf-opensans tini
 WORKDIR /invidious
 RUN addgroup -g 1000 -S invidious && \


### PR DESCRIPTION
Bumps the current alpine version from 3.16->3.18, and sets shards to compile with "1.8.2-r0" (as specified in the [install docs](https://docs.invidious.io/installation/#install-crystal))